### PR TITLE
Test against ClickHouse 26.3.12.3 (the version we ship)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
             -p 127.0.0.1:18123:8123 \
             --ulimit nofile=262144:262144 \
             -e CLICKHOUSE_SKIP_USER_SETUP=1 \
-            docker.io/clickhouse/clickhouse-server:24.8
+            docker.io/clickhouse/clickhouse-server:26.3.12.3
 
       - name: Wait for ClickHouse
         run: |

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -20,7 +20,7 @@
 #   bash scripts/e2e.sh
 #
 # Knobs (env vars with defaults):
-#   CH_IMAGE        ClickHouse server image  (default: docker.io/clickhouse/clickhouse-server:24.8)
+#   CH_IMAGE        ClickHouse server image  (default: docker.io/clickhouse/clickhouse-server:26.3.12.3)
 #   INGESTOR_IMAGE  Ingestor image           (default: localhost/ch-ingestor:local)
 #   NET             Podman network name      (default: ch_e2e_net)
 #   CH_CONTAINER    ClickHouse container     (default: ch_e2e_ch)
@@ -34,7 +34,7 @@
 set -euo pipefail
 
 # ── Configurable defaults ─────────────────────────────────────────────────────
-CH_IMAGE="${CH_IMAGE:-docker.io/clickhouse/clickhouse-server:24.8}"
+CH_IMAGE="${CH_IMAGE:-docker.io/clickhouse/clickhouse-server:26.3.12.3}"
 INGESTOR_IMAGE="${INGESTOR_IMAGE:-localhost/ch-ingestor:local}"
 NET="${NET:-ch_e2e_net}"
 CH_CONTAINER="${CH_CONTAINER:-ch_e2e_ch}"


### PR DESCRIPTION
The ingestor add-on ships ClickHouse 26.3.12.3 LTS, but the e2e harness and CI job spun up a 24.8 server — so the published version was never exercised end-to-end. Pin both to 26.3.12.3 to match production.

Verified locally: full ingestor e2e (insert, state_float parsing, JSON attributes, entity exclusion) passes against clickhouse-server:26.3.12.3 — 6/6 assertions.